### PR TITLE
Adding support for null Strings

### DIFF
--- a/stanley/build.gradle
+++ b/stanley/build.gradle
@@ -7,8 +7,8 @@ android {
 
     defaultConfig {
         minSdkVersion 8
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.1"
     }
     buildTypes {
         release {
@@ -31,7 +31,7 @@ publish {
     userOrg = 'iambmelton'
     groupId = 'com.brianjmelton'
     artifactId = 'stanley'
-    publishVersion = '1.0.0'
+    publishVersion = '1.0.1'
     description = 'Convenient stashing of simple data formats in SharedPreferences'
     website = 'https://github.com/iambmelt/Stanley'
 }

--- a/stanley/build.gradle
+++ b/stanley/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.2.10'
+        classpath 'com.novoda:bintray-release:0.3.0'
     }
 }
 

--- a/stanley/src/androidTest/java/com/brianjmelton/stanley/TestStringAccessor.java
+++ b/stanley/src/androidTest/java/com/brianjmelton/stanley/TestStringAccessor.java
@@ -2,6 +2,13 @@ package com.brianjmelton.stanley;
 
 public class TestStringAccessor extends AbstractTest {
 
+    public void testSetStringNull() throws Exception {
+        final String expectedNull = null;
+        proxy.setString(expectedNull);
+        String result = sharedPreferences.getString("String", null);
+        assertNull(result);
+    }
+
     public void testSetString() throws Exception {
         final String expected = "test string";
         proxy.setString(expected);

--- a/stanley/src/main/java/com/brianjmelton/stanley/ProxyGenerator.java
+++ b/stanley/src/main/java/com/brianjmelton/stanley/ProxyGenerator.java
@@ -108,7 +108,7 @@ public class ProxyGenerator {
                 return methodInfo.type.get(sharedPreferences, methodInfo);
             } else {
                 // setter
-                Class<?> paramType = args[0].getClass();
+                Class<?> paramType = method.getParameterTypes()[0];
                 persistenceDelegates.get(paramType)
                         .persist(sharedPreferences.edit(), methodInfo.key, args[0]);
             }

--- a/stanley/src/main/java/com/brianjmelton/stanley/ProxyGenerator.java
+++ b/stanley/src/main/java/com/brianjmelton/stanley/ProxyGenerator.java
@@ -108,7 +108,12 @@ public class ProxyGenerator {
                 return methodInfo.type.get(sharedPreferences, methodInfo);
             } else {
                 // setter
-                Class<?> paramType = method.getParameterTypes()[0];
+                Class<?> paramType;
+                if (null == args[0]) {
+                    paramType = method.getParameterTypes()[0];
+                } else {
+                    paramType = args[0].getClass();
+                }
                 persistenceDelegates.get(paramType)
                         .persist(sharedPreferences.edit(), methodInfo.key, args[0]);
             }


### PR DESCRIPTION
Note: primitive wrapper types and ```null``` aren't [and won't] be supported because the underlying API which abstract [doesn't support it](http://developer.android.com/reference/android/content/SharedPreferences.Editor.html).